### PR TITLE
feat: ai tool token optimizations

### DIFF
--- a/nodes/ApifyContentCrawler/resources/executeActor.ts
+++ b/nodes/ApifyContentCrawler/resources/executeActor.ts
@@ -1,5 +1,5 @@
 import { IExecuteFunctions, INodeExecutionData, NodeApiError } from 'n8n-workflow';
-import { apiRequest, getResults, pollRunStatus } from './genericFunctions';
+import { apiRequest, getResults, isUsedAsAiTool, pollRunStatus } from './genericFunctions';
 
 export async function getDefaultBuild(this: IExecuteFunctions, actorId: string) {
 	const defaultBuildResp = await apiRequest.call(this, {
@@ -63,5 +63,10 @@ export async function executeActorRunFlow(
 	const datasetId = run.data.defaultDatasetId;
 	const lastRunData = await pollRunStatus.call(this, runId);
 	const resultData = await getResults.call(this, datasetId);
+
+	if (isUsedAsAiTool(this.getNode().type)) {
+		return { json: { ...resultData } };
+	}
+
 	return { json: { ...lastRunData, ...resultData } };
 }


### PR DESCRIPTION
This PR is to solely improve the performance of the WCC Actor when it is used as an AI tool.

I use the `this.getNode().type` to determine whether or not it is used as an AI tool or as a regular workflow node
I asked the n8n team for this information.

If it is used as an AI tool I only return the scraping results in Markdown to reduce the total token count used.