### PR TITLE
fix: run data cleanup

### DIFF
--- a/nodes/ApifyContentCrawler/__tests__/Apify.node.spec.ts
+++ b/nodes/ApifyContentCrawler/__tests__/Apify.node.spec.ts
@@ -83,8 +83,7 @@ describe('Apify Node', () => {
 					const data = getTaskData(nodeResult);
 					expect(typeof data).toBe('object');
 
-					const first = data?.['0'] as { json: any };
-					expect(first.json).toEqual(mockResultDataset[0]);
+					expect(data).toEqual(mockResultDataset[0]);
 
 					console.log(`Pending mocks for ${workflowJsonName}:`, scope.pendingMocks());
 					expect(scope.isDone()).toBe(true);

--- a/nodes/ApifyContentCrawler/resources/executeActor.ts
+++ b/nodes/ApifyContentCrawler/resources/executeActor.ts
@@ -70,8 +70,10 @@ export async function executeActorRunFlow(
 		usageTotalUsd,
 		usage,
 		options,
-		status,
+		stats,
 		meta,
+		integrationTracking,
+		containerUrl,
 		...cleanedRunData
 	} = lastRunData;
 

--- a/nodes/ApifyContentCrawler/resources/executeActor.ts
+++ b/nodes/ApifyContentCrawler/resources/executeActor.ts
@@ -61,9 +61,9 @@ export async function executeActorRunFlow(
 
 	const runId = run.data.id;
 	const datasetId = run.data.defaultDatasetId;
-	
+
 	// Wait for Actor run to finish
 	await pollRunStatus.call(this, runId);
-	
+
 	return await getResults.call(this, datasetId);
 }

--- a/nodes/ApifyContentCrawler/resources/executeActor.ts
+++ b/nodes/ApifyContentCrawler/resources/executeActor.ts
@@ -1,5 +1,5 @@
 import { IExecuteFunctions, INodeExecutionData, NodeApiError } from 'n8n-workflow';
-import { apiRequest, getResults, isUsedAsAiTool, pollRunStatus } from './genericFunctions';
+import { apiRequest, getResults } from './genericFunctions';
 
 export async function getDefaultBuild(this: IExecuteFunctions, actorId: string) {
 	const defaultBuildResp = await apiRequest.call(this, {

--- a/nodes/ApifyContentCrawler/resources/executeActor.ts
+++ b/nodes/ApifyContentCrawler/resources/executeActor.ts
@@ -64,9 +64,20 @@ export async function executeActorRunFlow(
 	const lastRunData = await pollRunStatus.call(this, runId);
 	const resultData = await getResults.call(this, datasetId);
 
+	// Clean unecessery values from the lastRunData
+	const {
+		usageUsd,
+		usageTotalUsd,
+		usage,
+		options,
+		status,
+		meta,
+		...cleanedRunData
+	} = lastRunData;
+
 	if (isUsedAsAiTool(this.getNode().type)) {
 		return { json: { ...resultData } };
 	}
 
-	return { json: { ...lastRunData, ...resultData } };
+	return { json: { ...cleanedRunData, ...resultData } };
 }

--- a/nodes/ApifyContentCrawler/resources/executeActor.ts
+++ b/nodes/ApifyContentCrawler/resources/executeActor.ts
@@ -1,5 +1,5 @@
 import { IExecuteFunctions, INodeExecutionData, NodeApiError } from 'n8n-workflow';
-import { apiRequest, getResults } from './genericFunctions';
+import { apiRequest, getResults, pollRunStatus } from './genericFunctions';
 
 export async function getDefaultBuild(this: IExecuteFunctions, actorId: string) {
 	const defaultBuildResp = await apiRequest.call(this, {
@@ -59,6 +59,11 @@ export async function executeActorRunFlow(
 		});
 	}
 
+	const runId = run.data.id;
 	const datasetId = run.data.defaultDatasetId;
+	
+	// Wait for Actor run to finish
+	await pollRunStatus.call(this, runId);
+	
 	return await getResults.call(this, datasetId);
 }

--- a/nodes/ApifyContentCrawler/resources/executeActor.ts
+++ b/nodes/ApifyContentCrawler/resources/executeActor.ts
@@ -59,27 +59,8 @@ export async function executeActorRunFlow(
 		});
 	}
 
-	const runId = run.data.id;
 	const datasetId = run.data.defaultDatasetId;
-	const lastRunData = await pollRunStatus.call(this, runId);
 	const resultData = await getResults.call(this, datasetId);
 
-	// Clean unecessery values from the lastRunData
-	const {
-		usageUsd,
-		usageTotalUsd,
-		usage,
-		options,
-		stats,
-		meta,
-		integrationTracking,
-		containerUrl,
-		...cleanedRunData
-	} = lastRunData;
-
-	if (isUsedAsAiTool(this.getNode().type)) {
-		return { json: { ...resultData } };
-	}
-
-	return { json: { ...cleanedRunData, ...resultData } };
+	return resultData;
 }

--- a/nodes/ApifyContentCrawler/resources/executeActor.ts
+++ b/nodes/ApifyContentCrawler/resources/executeActor.ts
@@ -60,7 +60,5 @@ export async function executeActorRunFlow(
 	}
 
 	const datasetId = run.data.defaultDatasetId;
-	const resultData = await getResults.call(this, datasetId);
-
-	return resultData;
+	return await getResults.call(this, datasetId);
 }


### PR DESCRIPTION
Cleaning up the results from the Actor run. The run data had bunch of useless data such as costs of the run, some arbitrary stats etc.

PR for the review on Slack: https://apify.slack.com/archives/C08BYMR0EKE/p1754919905485839